### PR TITLE
Feature/pin code

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ erDiagram
         varchar phone_number
         date date_of_birth
         varchar role
+        varchar pin_hash "BCrypt, NULL = nieustawiony"
+        int pin_failed_attempts "licznik nieudanych prób"
+        timestamp pin_locked_until "blokada PIN do tego czasu"
     }
 
     ACCOUNTS {

--- a/backend/src/main/java/com/polishbank/bank_a/config/SecurityConfig.java
+++ b/backend/src/main/java/com/polishbank/bank_a/config/SecurityConfig.java
@@ -40,8 +40,8 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/webhooks/**").permitAll()
+                        .requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
+                        .requestMatchers("/api/auth/pin").authenticated()                        .requestMatchers("/api/webhooks/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthController.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthController.java
@@ -3,10 +3,14 @@ package com.polishbank.bank_a.domain.auth;
 import com.polishbank.bank_a.domain.auth.dto.AuthResponse;
 import com.polishbank.bank_a.domain.auth.dto.LoginRequest;
 import com.polishbank.bank_a.domain.auth.dto.RegisterRequest;
+import com.polishbank.bank_a.domain.auth.dto.SetPinRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final PinService pinService;
 
     @PostMapping("/register")
     public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
@@ -23,5 +28,12 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
+    }
+
+    @PostMapping("/pin")
+    public ResponseEntity<?> setPin(@Valid @RequestBody SetPinRequest request,
+                                    Authentication authentication) {
+        pinService.setPin(authentication.getName(), request.pin(), request.confirmPin());
+        return ResponseEntity.ok(Map.of("message", "PIN został ustawiony."));
     }
 }

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthService.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthService.java
@@ -38,7 +38,8 @@ public class AuthService {
                 .build();
         userRepository.save(user);
         String token = jwtUtil.generateToken(user.getEmail(), user.getRole().name());
-        return new AuthResponse(token, user.getEmail(), user.getRole().name(), user.getCustomerNumber());
+        return new AuthResponse(token, user.getEmail(), user.getRole().name(),
+                user.getCustomerNumber(), user.getPinHash() != null);
     }
 
     public AuthResponse login(LoginRequest request) {
@@ -48,7 +49,8 @@ public class AuthService {
                 new UsernamePasswordAuthenticationToken(user.getEmail(), request.password())
         );
         String token = jwtUtil.generateToken(user.getEmail(), user.getRole().name());
-        return new AuthResponse(token, user.getEmail(), user.getRole().name(), user.getCustomerNumber());
+        return new AuthResponse(token, user.getEmail(), user.getRole().name(),
+                user.getCustomerNumber(), user.getPinHash() != null);
     }
 
     private String generateCustomerNumber() {

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinLockoutTracker.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinLockoutTracker.java
@@ -17,16 +17,19 @@ public class PinLockoutTracker {
     private final UserRepository userRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void recordFailure(UUID userId, int maxAttempts, int lockoutMinutes) {
+    public LocalDateTime recordFailure(UUID userId, int maxAttempts, int lockoutMinutes) {
         User user = userRepository.findById(userId).orElseThrow();
         int attempts = user.getPinFailedAttempts() + 1;
         if (attempts >= maxAttempts) {
-            user.setPinLockedUntil(LocalDateTime.now().plusMinutes(lockoutMinutes));
+            LocalDateTime lockedUntil = LocalDateTime.now().plusMinutes(lockoutMinutes);
+            user.setPinLockedUntil(lockedUntil);
             user.setPinFailedAttempts(0);
-        } else {
-            user.setPinFailedAttempts(attempts);
+            userRepository.save(user);
+            return lockedUntil;
         }
+        user.setPinFailedAttempts(attempts);
         userRepository.save(user);
+        return null;
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinLockoutTracker.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinLockoutTracker.java
@@ -1,0 +1,41 @@
+package com.polishbank.bank_a.domain.auth;
+
+import com.polishbank.bank_a.domain.user.User;
+import com.polishbank.bank_a.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PinLockoutTracker {
+
+    private final UserRepository userRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordFailure(UUID userId, int maxAttempts, int lockoutMinutes) {
+        User user = userRepository.findById(userId).orElseThrow();
+        int attempts = user.getPinFailedAttempts() + 1;
+        if (attempts >= maxAttempts) {
+            user.setPinLockedUntil(LocalDateTime.now().plusMinutes(lockoutMinutes));
+            user.setPinFailedAttempts(0);
+        } else {
+            user.setPinFailedAttempts(attempts);
+        }
+        userRepository.save(user);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordSuccess(UUID userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        if (user.getPinFailedAttempts() != 0 || user.getPinLockedUntil() != null) {
+            user.setPinFailedAttempts(0);
+            user.setPinLockedUntil(null);
+            userRepository.save(user);
+        }
+    }
+}

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinService.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinService.java
@@ -1,0 +1,75 @@
+package com.polishbank.bank_a.domain.auth;
+
+import com.polishbank.bank_a.domain.user.User;
+import com.polishbank.bank_a.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PinService {
+
+    private static final int MAX_FAILED_ATTEMPTS = 3;
+    private static final int LOCKOUT_MINUTES = 15;
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final PinLockoutTracker lockoutTracker;
+
+    @Transactional
+    public void setPin(String email, String pin, String confirmPin) {
+        if (!pin.equals(confirmPin)) {
+            throw new IllegalArgumentException("Wpisane kody PIN nie są identyczne.");
+        }
+        if (!pin.matches("\\d{4}")) {
+            throw new IllegalArgumentException("PIN musi składać się z dokładnie 4 cyfr.");
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Użytkownik nie znaleziony."));
+
+        if (user.getPinHash() != null) {
+            throw new IllegalStateException("PIN został już ustawiony. Zmiana PIN-u nie jest jeszcze obsługiwana.");
+        }
+
+        user.setPinHash(passwordEncoder.encode(pin));
+        user.setPinFailedAttempts(0);
+        user.setPinLockedUntil(null);
+        userRepository.save(user);
+    }
+
+    public void verifyPin(User user, String pin) {
+        if (user.getPinHash() == null) {
+            throw new IllegalStateException("Najpierw ustaw kod PIN, aby zatwierdzać operacje finansowe.");
+        }
+        if (pin == null || !pin.matches("\\d{4}")) {
+            throw new IllegalArgumentException("PIN musi składać się z dokładnie 4 cyfr.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (user.getPinLockedUntil() != null && user.getPinLockedUntil().isAfter(now)) {
+            long minutesLeft = java.time.Duration.between(now, user.getPinLockedUntil()).toMinutes() + 1;
+            throw new IllegalStateException(
+                    "PIN został zablokowany po zbyt wielu nieudanych próbach. Spróbuj ponownie za "
+                            + minutesLeft + " min.");
+        }
+
+        if (!passwordEncoder.matches(pin, user.getPinHash())) {
+            lockoutTracker.recordFailure(user.getId(), MAX_FAILED_ATTEMPTS, LOCKOUT_MINUTES);
+            int attemptsAfter = user.getPinFailedAttempts() + 1;
+            if (attemptsAfter >= MAX_FAILED_ATTEMPTS) {
+                throw new IllegalStateException(
+                        "Wprowadzono nieprawidłowy PIN " + MAX_FAILED_ATTEMPTS
+                                + " razy z rzędu. Konto zostało zablokowane na " + LOCKOUT_MINUTES + " minut.");
+            }
+            int left = MAX_FAILED_ATTEMPTS - attemptsAfter;
+            throw new IllegalArgumentException("Nieprawidłowy PIN. Pozostało prób: " + left + ".");
+        }
+
+        lockoutTracker.recordSuccess(user.getId());
+    }
+}

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinService.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/PinService.java
@@ -2,6 +2,7 @@ package com.polishbank.bank_a.domain.auth;
 
 import com.polishbank.bank_a.domain.user.User;
 import com.polishbank.bank_a.domain.user.UserRepository;
+import com.polishbank.bank_a.exception.PinLockedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -52,20 +53,16 @@ public class PinService {
 
         LocalDateTime now = LocalDateTime.now();
         if (user.getPinLockedUntil() != null && user.getPinLockedUntil().isAfter(now)) {
-            long minutesLeft = java.time.Duration.between(now, user.getPinLockedUntil()).toMinutes() + 1;
-            throw new IllegalStateException(
-                    "PIN został zablokowany po zbyt wielu nieudanych próbach. Spróbuj ponownie za "
-                            + minutesLeft + " min.");
+            throw new PinLockedException(user.getPinLockedUntil());
         }
 
         if (!passwordEncoder.matches(pin, user.getPinHash())) {
-            lockoutTracker.recordFailure(user.getId(), MAX_FAILED_ATTEMPTS, LOCKOUT_MINUTES);
-            int attemptsAfter = user.getPinFailedAttempts() + 1;
-            if (attemptsAfter >= MAX_FAILED_ATTEMPTS) {
-                throw new IllegalStateException(
-                        "Wprowadzono nieprawidłowy PIN " + MAX_FAILED_ATTEMPTS
-                                + " razy z rzędu. Konto zostało zablokowane na " + LOCKOUT_MINUTES + " minut.");
+            LocalDateTime lockedUntil = lockoutTracker.recordFailure(
+                    user.getId(), MAX_FAILED_ATTEMPTS, LOCKOUT_MINUTES);
+            if (lockedUntil != null) {
+                throw new PinLockedException(lockedUntil);
             }
+            int attemptsAfter = user.getPinFailedAttempts() + 1;
             int left = MAX_FAILED_ATTEMPTS - attemptsAfter;
             throw new IllegalArgumentException("Nieprawidłowy PIN. Pozostało prób: " + left + ".");
         }

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/dto/AuthResponse.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/dto/AuthResponse.java
@@ -1,4 +1,9 @@
 package com.polishbank.bank_a.domain.auth.dto;
 
-public record AuthResponse(String token, String email, String role, String customerNumber) {
-}
+public record AuthResponse(
+        String token,
+        String email,
+        String role,
+        String customerNumber,
+        boolean pinSet
+) {}

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/dto/SetPinRequest.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/dto/SetPinRequest.java
@@ -1,0 +1,14 @@
+package com.polishbank.bank_a.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SetPinRequest(
+        @NotBlank
+        @Pattern(regexp = "\\d{4}", message = "PIN musi składać się z dokładnie 4 cyfr")
+        String pin,
+
+        @NotBlank
+        @Pattern(regexp = "\\d{4}", message = "PIN musi składać się z dokładnie 4 cyfr")
+        String confirmPin
+) {}

--- a/backend/src/main/java/com/polishbank/bank_a/domain/transaction/TransactionService.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/transaction/TransactionService.java
@@ -1,5 +1,6 @@
 package com.polishbank.bank_a.domain.transaction;
 
+import com.polishbank.bank_a.domain.auth.PinService;
 import com.polishbank.bank_a.domain.transaction.dto.InternalTransferRequest;
 import com.polishbank.bank_a.domain.transaction.dto.TransactionResponse;
 import com.polishbank.bank_a.domain.user.User;
@@ -24,6 +25,7 @@ public class TransactionService {
     private final AccountRepository accountRepository;
     private final TransactionRepository transactionRepository;
     private final UserRepository userRepository;
+    private final PinService pinService;
 
     @Transactional
     public void processInternalTransfer(InternalTransferRequest request, String customerNumber) {
@@ -33,6 +35,8 @@ public class TransactionService {
         if (!senderAccount.getUser().getCustomerNumber().equals(customerNumber)) {
             throw new IllegalStateException("Brak uprawnień do tego konta.");
         }
+
+        pinService.verifyPin(senderAccount.getUser(), request.pin());
 
         Account receiverAccount = accountRepository.findByAccountNumber(request.receiverAccountNumber())
                 .orElseThrow(() -> new IllegalArgumentException("Nie znaleziono konta odbiorcy w naszym banku."));

--- a/backend/src/main/java/com/polishbank/bank_a/domain/transaction/dto/InternalTransferRequest.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/transaction/dto/InternalTransferRequest.java
@@ -3,20 +3,25 @@ package com.polishbank.bank_a.domain.transaction.dto;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.math.BigDecimal;
 import java.util.UUID;
 
 public record InternalTransferRequest(
     @NotNull(message = "Musisz wybrać konto nadawcy")
     UUID senderAccountId,
-    
+
     @NotBlank(message = "Numer konta odbiorcy nie może być pusty")
     String receiverAccountNumber,
-    
+
     @NotNull(message = "Kwota przelewu jest wymagana")
     @DecimalMin(value = "0.01", message = "Kwota przelewu musi być większa od zera")
     BigDecimal amount,
-    
+
     @NotBlank(message = "Tytuł przelewu jest wymagany")
-    String title
+    String title,
+
+    @NotBlank(message = "PIN jest wymagany do potwierdzenia przelewu")
+    @Pattern(regexp = "\\d{4}", message = "PIN musi składać się z dokładnie 4 cyfr")
+    String pin
 ) {}

--- a/backend/src/main/java/com/polishbank/bank_a/domain/user/User.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/user/User.java
@@ -3,6 +3,7 @@ package com.polishbank.bank_a.domain.user;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -38,4 +39,14 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 50)
     private UserRole role;
+
+    @Column(name = "pin_hash", length = 255)
+    private String pinHash;
+
+    @Column(name = "pin_failed_attempts", nullable = false)
+    @Builder.Default
+    private int pinFailedAttempts = 0;
+
+    @Column(name = "pin_locked_until")
+    private LocalDateTime pinLockedUntil;
 }

--- a/backend/src/main/java/com/polishbank/bank_a/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/polishbank/bank_a/exception/GlobalExceptionHandler.java
@@ -2,17 +2,42 @@ package com.polishbank.bank_a.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.ZoneId;
+import java.util.Map;
+import java.time.ZoneId;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(PinLockedException.class)
+    public ResponseEntity<Map<String, Object>> handlePinLocked(PinLockedException ex) {
+        String lockedUntilIso = ex.getLockedUntil()
+                .atZone(ZoneId.systemDefault())
+                .toOffsetDateTime()
+                .toString();
+        return ResponseEntity.status(HttpStatus.LOCKED).body(Map.of(
+                "message", ex.getMessage(),
+                "lockedUntil", lockedUntilIso,
+                "pinLocked", true
+        ));
+    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ProblemDetail handleIllegalArgument(IllegalArgumentException ex) {
         ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
         pd.setTitle("Bad Request");
+        return pd;
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ProblemDetail handleIllegalState(IllegalStateException ex) {
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        pd.setTitle("Conflict");
         return pd;
     }
 

--- a/backend/src/main/java/com/polishbank/bank_a/exception/PinLockedException.java
+++ b/backend/src/main/java/com/polishbank/bank_a/exception/PinLockedException.java
@@ -1,0 +1,16 @@
+package com.polishbank.bank_a.exception;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PinLockedException extends RuntimeException {
+
+    private final LocalDateTime lockedUntil;
+
+    public PinLockedException(LocalDateTime lockedUntil) {
+        super("PIN został zablokowany po zbyt wielu nieudanych próbach.");
+        this.lockedUntil = lockedUntil;
+    }
+}

--- a/backend/src/main/java/com/polishbank/bank_a/seeder/DataSeeder.java
+++ b/backend/src/main/java/com/polishbank/bank_a/seeder/DataSeeder.java
@@ -41,35 +41,36 @@ public class DataSeeder implements CommandLineRunner {
 
         String defaultPassword = passwordEncoder.encode("password");
 
-        
+        String defaultPinHash = passwordEncoder.encode("1234");
+
         // 1. UŻYTKOWNICY
         User admin = userRepository.save(User.builder().customerNumber("99000001").firstName("Jan").lastName("Kowalski")
                 .email("admin@banka.pl").phoneNumber("48111222333").dateOfBirth(LocalDate.of(1980, 1, 1))
-                .passwordHash(defaultPassword).role(UserRole.ADMIN).build());
+                .passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.ADMIN).build());
         User parentEwa = userRepository.save(User.builder().customerNumber("84920183").firstName("Ewa")
                 .lastName("Majewska").email("ewa.majewska@gmail.com").phoneNumber("48600100200")
-                .dateOfBirth(LocalDate.of(1985, 5, 15)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(1985, 5, 15)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
         User juniorJanek = userRepository.save(User.builder().customerNumber("12847593").firstName("Jan")
                 .lastName("Majewski").email("janek.m@gmail.com").phoneNumber("48600100201")
-                .dateOfBirth(LocalDate.of(2015, 8, 20)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(2015, 8, 20)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
         User juniorZuzia = userRepository.save(User.builder().customerNumber("58392011").firstName("Zuzanna")
                 .lastName("Majewska").email("zuzia.m@gmail.com").phoneNumber("48600100202")
-                .dateOfBirth(LocalDate.of(2013, 11, 10)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(2013, 11, 10)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
         User parentAnna = userRepository.save(User.builder().customerNumber("67291028").firstName("Anna")
                 .lastName("Nowak").email("anna.nowak@gmail.com").phoneNumber("48700300400")
-                .dateOfBirth(LocalDate.of(1990, 7, 22)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(1990, 7, 22)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
         User juniorPiotr = userRepository.save(User.builder().customerNumber("48192038").firstName("Piotr")
                 .lastName("Nowak").email("piotrek.junior@gmail.com").phoneNumber("48700300401")
-                .dateOfBirth(LocalDate.of(2014, 4, 12)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(2014, 4, 12)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
         User michal = userRepository.save(User.builder().customerNumber("51829304").firstName("Michał")
                 .lastName("Wiśniewski").email("michal.w@firma.pl").phoneNumber("48500600700")
-                .dateOfBirth(LocalDate.of(1992, 9, 9)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(1992, 9, 9)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
         User katarzyna = userRepository.save(User.builder().customerNumber("39481726").firstName("Katarzyna")
                 .lastName("Zielińska").email("kasia.z@korpo.com").phoneNumber("48800900100")
-                .dateOfBirth(LocalDate.of(1988, 12, 1)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(1988, 12, 1)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
         User podejrzany = userRepository.save(User.builder().customerNumber("11847265").firstName("Olaf")
                 .lastName("Kombinator").email("olaf.k@darknet.pl").phoneNumber("48999000999")
-                .dateOfBirth(LocalDate.of(1975, 3, 15)).passwordHash(defaultPassword).role(UserRole.CUSTOMER).build());
+                .dateOfBirth(LocalDate.of(1975, 3, 15)).passwordHash(defaultPassword).pinHash(defaultPinHash).role(UserRole.CUSTOMER).build());
 
                 
         // 2. KONTA BANKOWE (Identyfikator banku: 88880000)

--- a/backend/src/main/resources/db/migration/V2__add_pin.sql
+++ b/backend/src/main/resources/db/migration/V2__add_pin.sql
@@ -1,0 +1,5 @@
+-- Dodanie obsługi PIN-u (4 cyfry, hashowany BCryptem) + mechanizm blokady po nieudanych próbach
+ALTER TABLE users
+    ADD COLUMN pin_hash VARCHAR(255),
+    ADD COLUMN pin_failed_attempts INT NOT NULL DEFAULT 0,
+    ADD COLUMN pin_locked_until TIMESTAMP;

--- a/backend/src/test/java/com/polishbank/bank_a/domain/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/polishbank/bank_a/domain/auth/AuthServiceTest.java
@@ -56,7 +56,7 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.register(request))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Email already in use");
+                .hasMessage("Email już jest w użyciu");
 
         verify(userRepository, never()).save(any());
     }

--- a/docs/ERD_kod.mmd
+++ b/docs/ERD_kod.mmd
@@ -12,6 +12,9 @@ erDiagram
         varchar phone_number
         date date_of_birth
         varchar role
+        varchar pin_hash "BCrypt, NULL = nieustawiony"
+        int pin_failed_attempts "licznik nieudanych prób"
+        timestamp pin_locked_until "blokada PIN do tego czasu"
     }
 
     ACCOUNTS {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { ProtectedRoute } from './components/layout/ProtectedRoute.tsx'
 import Home from './pages/Home.tsx'
 import Login from './pages/auth/Login.tsx'
 import Register from './pages/auth/Register.tsx'
+import SetupPin from './pages/auth/SetupPin.tsx'
 import Dashboard from './pages/Dashboard.tsx'
 import TransactionHistory from './pages/TransactionHistory';
 import InternalTransfer from './pages/auth/InternalTransfer';
@@ -19,7 +20,13 @@ function App() {
         <Route path={ROUTES.HOME} element={<Home/>}/>
         <Route path={ROUTES.LOGIN} element={<Login/>}/>
         <Route path={ROUTES.REGISTER} element={<Register/>}/>
-        
+
+        <Route path={ROUTES.SETUP_PIN} element={
+          <ProtectedRoute>
+            <SetupPin/>
+          </ProtectedRoute>
+        } />
+
         <Route path={ROUTES.DASHBOARD} element = {
           <ProtectedRoute>
             <Dashboard/>

--- a/frontend/src/constants/routes.tsx
+++ b/frontend/src/constants/routes.tsx
@@ -2,6 +2,7 @@ export const ROUTES = {
     HOME: "/",
     LOGIN: '/login',
     REGISTER: '/register',
+    SETUP_PIN: '/setup-pin',
     DASHBOARD: '/dashboard',
     INTERNAL_TRANSFER: '/transfer/internal',
     TRANSACTION_HISTORY: '/history/:accountId',

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,12 +2,13 @@ import { createContext, useContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { authService } from '../services/authService';
 
-interface AuthUser { email: string; role: string; customerNumber: string }
+interface AuthUser { email: string; role: string; customerNumber: string; pinSet: boolean }
 
 interface AuthContextType {
   user: AuthUser | null;
   login: (customerNumber: string, password: string) => Promise<void>;
   register: (firstName: string, lastName: string, email: string, password: string) => Promise<string>;
+  setPin: (pin: string, confirmPin: string) => Promise<void>;
   logout: () => void;
   isAuthenticated: boolean;
 }
@@ -22,22 +23,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (token) {
       try {
         const payload = JSON.parse(atob(token.split('.')[1]));
-        setUser({ email: payload.sub, role: payload.role, customerNumber: payload.customerNumber ?? '' });
+        const pinSet = localStorage.getItem('pinSet') === 'true';
+        setUser({
+          email: payload.sub,
+          role: payload.role,
+          customerNumber: payload.customerNumber ?? '',
+          pinSet,
+        });
       } catch {
         localStorage.removeItem('token');
+        localStorage.removeItem('pinSet');
       }
     }
   }, []);
 
   const login = async (customerNumber: string, password: string) => {
     const res = await authService.login(customerNumber, password);
-    setUser({ email: res.email, role: res.role, customerNumber: res.customerNumber });
+    setUser({ email: res.email, role: res.role, customerNumber: res.customerNumber, pinSet: res.pinSet });
   };
 
   const register = async (firstName: string, lastName: string, email: string, password: string): Promise<string> => {
     const res = await authService.register(firstName, lastName, email, password);
-    setUser({ email: res.email, role: res.role, customerNumber: res.customerNumber });
+    setUser({ email: res.email, role: res.role, customerNumber: res.customerNumber, pinSet: res.pinSet });
     return res.customerNumber;
+  };
+
+  const setPin = async (pin: string, confirmPin: string) => {
+    await authService.setPin(pin, confirmPin);
+    setUser((u) => (u ? { ...u, pinSet: true } : u));
   };
 
   const logout = () => {
@@ -47,7 +60,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout, isAuthenticated: !!user }}>
+    <AuthContext.Provider value={{ user, login, register, setPin, logout, isAuthenticated: !!user }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/auth/InternalTransfer.tsx
+++ b/frontend/src/pages/auth/InternalTransfer.tsx
@@ -30,6 +30,9 @@ export default function InternalTransfer() {
   const [pin, setPin] = useState('');
   const [pinError, setPinError] = useState<string | null>(null);
 
+  const [lockedUntil, setLockedUntil] = useState<Date | null>(null);
+  const [nowTs, setNowTs] = useState<number>(() => Date.now());
+
   const loadAccounts = async () => {
     try {
       const response = await api.get('/api/accounts');
@@ -47,6 +50,20 @@ export default function InternalTransfer() {
   useEffect(() => {
     loadAccounts();
   }, []);
+
+  useEffect(() => {
+  if (!lockedUntil) return;
+  setNowTs(Date.now());
+  const id = setInterval(() => setNowTs(Date.now()), 1000);
+  return () => clearInterval(id);
+}, [lockedUntil]);
+
+useEffect(() => {
+  if (lockedUntil && nowTs >= lockedUntil.getTime()) {
+    setLockedUntil(null);
+    setPinError(null);
+  }
+}, [nowTs, lockedUntil]);
 
   const validateForm = () => {
     const errors: Record<string, string> = {};
@@ -81,41 +98,50 @@ export default function InternalTransfer() {
   };
 
   const confirmWithPin = async () => {
-    if (!/^\d{4}$/.test(pin)) {
-      setPinError("PIN musi składać się z dokładnie 4 cyfr.");
-      return;
-    }
-    setPinError(null);
-    setIsSubmitting(true);
-    const cleanReceiverNumber = receiverAccountNumber.replace(/\s+/g, '');
+  if (lockedUntil) return;
+  if (!/^\d{4}$/.test(pin)) {
+    setPinError("PIN musi składać się z dokładnie 4 cyfr.");
+    return;
+  }
+  setPinError(null);
+  setIsSubmitting(true);
+  const cleanReceiverNumber = receiverAccountNumber.replace(/\s+/g, '');
 
-    try {
-      await api.post('/api/transactions/internal', {
-        senderAccountId,
-        receiverAccountNumber: cleanReceiverNumber,
-        amount: parseFloat(amount),
-        title,
-        pin,
-      });
+  try {
+    await api.post('/api/transactions/internal', {
+      senderAccountId,
+      receiverAccountNumber: cleanReceiverNumber,
+      amount: parseFloat(amount),
+      title,
+      pin,
+    });
 
-      setSuccess(true);
-      setReceiverAccountNumber('');
-      setAmount('');
-      setTitle('');
-      setFieldErrors({});
-      setShowPinModal(false);
+    setSuccess(true);
+    setReceiverAccountNumber('');
+    setAmount('');
+    setTitle('');
+    setFieldErrors({});
+    setShowPinModal(false);
+    setPin('');
+  } catch (err: any) {
+    const status = err.response?.status;
+    const data = err.response?.data;
+    if (status === 423 && data?.lockedUntil) {
+      setLockedUntil(new Date(data.lockedUntil));
       setPin('');
-
-      await loadAccounts();
-    } catch (err: any) {
-      const msg = err.response?.data?.message
-        || err.response?.data?.errors?.[0]?.defaultMessage
+      setPinError(null);
+    } else {
+      const msg = data?.detail
+        || data?.message
+        || data?.errors?.[0]?.defaultMessage
         || "Wystąpił błąd podczas realizacji przelewu.";
       setPinError(msg);
-    } finally {
-      setIsSubmitting(false);
     }
-  };
+  } finally {
+    setIsSubmitting(false);
+    await loadAccounts();
+  }
+};
 
   const formatCurrency = (value: number, currency: string) => {
     return new Intl.NumberFormat('pl-PL', { style: 'currency', currency }).format(value);
@@ -128,6 +154,13 @@ export default function InternalTransfer() {
       </div>
     );
   }
+
+  const formatCountdown = (ms: number) => {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+};
 
   return (
     <div className="min-h-screen bg-zinc-950 text-white font-sans flex flex-col">
@@ -246,56 +279,91 @@ export default function InternalTransfer() {
       </main>
 
       {showPinModal && (
-        <div className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center px-4">
-          <div className="w-full max-w-sm bg-zinc-900 border border-zinc-800 rounded-2xl p-6 shadow-2xl">
-            <h3 className="text-lg font-semibold text-white text-center mb-1">Potwierdź PIN-em</h3>
-            <p className="text-zinc-500 text-sm text-center mb-5">
-              Wpisz 4-cyfrowy kod PIN, aby zatwierdzić przelew.
-            </p>
-
-            <input
-              type="password"
-              inputMode="numeric"
-              autoFocus
-              value={pin}
-              onChange={(e) => {
-                setPin(e.target.value.replace(/\D/g, '').slice(0, 4));
-                setPinError(null);
-              }}
-              placeholder="••••"
-              maxLength={4}
-              className="w-full bg-zinc-800 border border-zinc-700 text-white text-center tracking-[0.6em] text-2xl rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-colors"
-            />
-
-            {pinError && (
-              <p className="text-red-400 text-xs mt-2 text-center">{pinError}</p>
-            )}
-
-            <div className="flex gap-3 mt-5">
-              <button
-                type="button"
-                onClick={() => { setShowPinModal(false); setPin(''); setPinError(null); }}
-                disabled={isSubmitting}
-                className="flex-1 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 font-medium py-2.5 rounded-lg text-sm transition-colors disabled:opacity-50"
-              >
-                Anuluj
-              </button>
-              <button
-                type="button"
-                onClick={confirmWithPin}
-                disabled={isSubmitting || pin.length !== 4}
-                className="flex-1 bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg text-sm transition-colors flex items-center justify-center gap-2"
-              >
-                {isSubmitting ? (
-                  <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-white"></div>
-                ) : (
-                  'Potwierdź'
-                )}
-              </button>
-            </div>
+  <div className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center px-4">
+    <div className="w-full max-w-sm bg-zinc-900 border border-zinc-800 rounded-2xl p-6 shadow-2xl">
+      {lockedUntil ? (
+        <>
+          <div className="w-14 h-14 bg-red-500/10 border border-red-500/30 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-7 w-7 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
           </div>
-        </div>
+          <h3 className="text-lg font-semibold text-white text-center mb-1">PIN został zablokowany</h3>
+          <p className="text-zinc-400 text-sm text-center mb-5">
+            Wpisałeś nieprawidłowy PIN zbyt wiele razy. Z powodów bezpieczeństwa
+            potwierdzanie transakcji jest tymczasowo niedostępne.
+          </p>
+
+          <div className="bg-zinc-950 border border-red-500/30 rounded-xl px-4 py-5 mb-5 text-center">
+            <p className="text-xs uppercase tracking-wider text-zinc-500 mb-1">Pozostały czas blokady</p>
+            <p className="text-4xl font-mono font-bold text-red-400 tabular-nums">
+              {formatCountdown(lockedUntil.getTime() - nowTs)}
+            </p>
+            <p className="text-xs text-zinc-600 mt-2">
+              Odblokowanie: {lockedUntil.toLocaleTimeString('pl-PL')}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => { setShowPinModal(false); }}
+            className="w-full bg-zinc-800 hover:bg-zinc-700 text-zinc-200 font-medium py-2.5 rounded-lg text-sm transition-colors"
+          >
+            Zamknij
+          </button>
+        </>
+      ) : (
+        <>
+          <h3 className="text-lg font-semibold text-white text-center mb-1">Potwierdź PIN-em</h3>
+          <p className="text-zinc-500 text-sm text-center mb-5">
+            Wpisz 4-cyfrowy kod PIN, aby zatwierdzić przelew.
+          </p>
+
+          <input
+            type="password"
+            inputMode="numeric"
+            autoFocus
+            value={pin}
+            onChange={(e) => {
+              setPin(e.target.value.replace(/\D/g, '').slice(0, 4));
+              setPinError(null);
+            }}
+            placeholder="••••"
+            maxLength={4}
+            className="w-full bg-zinc-800 border border-zinc-700 text-white text-center tracking-[0.6em] text-2xl rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-colors"
+          />
+
+          {pinError && (
+            <p className="text-red-400 text-xs mt-2 text-center">{pinError}</p>
+          )}
+
+          <div className="flex gap-3 mt-5">
+            <button
+              type="button"
+              onClick={() => { setShowPinModal(false); setPin(''); setPinError(null); }}
+              disabled={isSubmitting}
+              className="flex-1 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 font-medium py-2.5 rounded-lg text-sm transition-colors disabled:opacity-50"
+            >
+              Anuluj
+            </button>
+            <button
+              type="button"
+              onClick={confirmWithPin}
+              disabled={isSubmitting || pin.length !== 4}
+              className="flex-1 bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg text-sm transition-colors flex items-center justify-center gap-2"
+            >
+              {isSubmitting ? (
+                <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-white"></div>
+              ) : (
+                'Potwierdź'
+              )}
+            </button>
+          </div>
+        </>
       )}
+    </div>
+  </div>
+)}
     </div>
   );
 }

--- a/frontend/src/pages/auth/InternalTransfer.tsx
+++ b/frontend/src/pages/auth/InternalTransfer.tsx
@@ -12,7 +12,7 @@ interface AccountSummary {
 
 export default function InternalTransfer() {
   const navigate = useNavigate();
-  
+
   const [accounts, setAccounts] = useState<AccountSummary[]>([]);
   const [senderAccountId, setSenderAccountId] = useState('');
   const [receiverAccountNumber, setReceiverAccountNumber] = useState('');
@@ -26,6 +26,10 @@ export default function InternalTransfer() {
 
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
+  const [showPinModal, setShowPinModal] = useState(false);
+  const [pin, setPin] = useState('');
+  const [pinError, setPinError] = useState<string | null>(null);
+
   const loadAccounts = async () => {
     try {
       const response = await api.get('/api/accounts');
@@ -33,7 +37,7 @@ export default function InternalTransfer() {
       if (response.data.length > 0 && !senderAccountId) {
         setSenderAccountId(response.data[0].id);
       }
-    } catch (err: any) {
+    } catch {
       setError("Nie udało się pobrać Twoich kont. Spróbuj odświeżyć stronę.");
     } finally {
       setIsLoading(false);
@@ -66,15 +70,22 @@ export default function InternalTransfer() {
     return Object.keys(errors).length === 0;
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
     setSuccess(false);
+    if (!validateForm()) return;
+    setPin('');
+    setPinError(null);
+    setShowPinModal(true);
+  };
 
-    if (!validateForm()) {
+  const confirmWithPin = async () => {
+    if (!/^\d{4}$/.test(pin)) {
+      setPinError("PIN musi składać się z dokładnie 4 cyfr.");
       return;
     }
-
+    setPinError(null);
     setIsSubmitting(true);
     const cleanReceiverNumber = receiverAccountNumber.replace(/\s+/g, '');
 
@@ -83,26 +94,31 @@ export default function InternalTransfer() {
         senderAccountId,
         receiverAccountNumber: cleanReceiverNumber,
         amount: parseFloat(amount),
-        title
+        title,
+        pin,
       });
-      
+
       setSuccess(true);
       setReceiverAccountNumber('');
       setAmount('');
       setTitle('');
       setFieldErrors({});
-      
+      setShowPinModal(false);
+      setPin('');
+
       await loadAccounts();
-      
     } catch (err: any) {
-      setError(err.response?.data?.message || err.response?.data?.errors?.[0]?.defaultMessage || "Wystąpił błąd podczas realizacji przelewu.");
+      const msg = err.response?.data?.message
+        || err.response?.data?.errors?.[0]?.defaultMessage
+        || "Wystąpił błąd podczas realizacji przelewu.";
+      setPinError(msg);
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const formatCurrency = (amount: number, currency: string) => {
-    return new Intl.NumberFormat('pl-PL', { style: 'currency', currency }).format(amount);
+  const formatCurrency = (value: number, currency: string) => {
+    return new Intl.NumberFormat('pl-PL', { style: 'currency', currency }).format(value);
   };
 
   if (isLoading) {
@@ -129,7 +145,7 @@ export default function InternalTransfer() {
 
       <main className="flex-grow p-4 md:p-8 flex justify-center items-start pt-12">
         <div className="w-full max-w-xl bg-zinc-900 border border-zinc-800 rounded-2xl p-6 md:p-8 shadow-xl">
-          
+
           <div className="mb-8 text-center">
             <div className="w-12 h-12 bg-blue-500/10 text-blue-400 rounded-full flex items-center justify-center mx-auto mb-4">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
@@ -220,19 +236,66 @@ export default function InternalTransfer() {
 
             <button
               type="submit"
-              disabled={isSubmitting || accounts.length === 0}
+              disabled={accounts.length === 0}
               className="w-full bg-blue-600 hover:bg-blue-500 text-white font-medium py-3.5 rounded-xl transition-colors mt-6 disabled:opacity-50 disabled:cursor-not-allowed flex justify-center items-center gap-2"
             >
-              {isSubmitting ? (
-                <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-white"></div>
-              ) : (
-                'Wykonaj przelew'
-              )}
+              Wykonaj przelew
             </button>
           </form>
-
         </div>
       </main>
+
+      {showPinModal && (
+        <div className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center px-4">
+          <div className="w-full max-w-sm bg-zinc-900 border border-zinc-800 rounded-2xl p-6 shadow-2xl">
+            <h3 className="text-lg font-semibold text-white text-center mb-1">Potwierdź PIN-em</h3>
+            <p className="text-zinc-500 text-sm text-center mb-5">
+              Wpisz 4-cyfrowy kod PIN, aby zatwierdzić przelew.
+            </p>
+
+            <input
+              type="password"
+              inputMode="numeric"
+              autoFocus
+              value={pin}
+              onChange={(e) => {
+                setPin(e.target.value.replace(/\D/g, '').slice(0, 4));
+                setPinError(null);
+              }}
+              placeholder="••••"
+              maxLength={4}
+              className="w-full bg-zinc-800 border border-zinc-700 text-white text-center tracking-[0.6em] text-2xl rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-colors"
+            />
+
+            {pinError && (
+              <p className="text-red-400 text-xs mt-2 text-center">{pinError}</p>
+            )}
+
+            <div className="flex gap-3 mt-5">
+              <button
+                type="button"
+                onClick={() => { setShowPinModal(false); setPin(''); setPinError(null); }}
+                disabled={isSubmitting}
+                className="flex-1 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 font-medium py-2.5 rounded-lg text-sm transition-colors disabled:opacity-50"
+              >
+                Anuluj
+              </button>
+              <button
+                type="button"
+                onClick={confirmWithPin}
+                disabled={isSubmitting || pin.length !== 4}
+                className="flex-1 bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg text-sm transition-colors flex items-center justify-center gap-2"
+              >
+                {isSubmitting ? (
+                  <div className="animate-spin rounded-full h-5 w-5 border-t-2 border-b-2 border-white"></div>
+                ) : (
+                  'Potwierdź'
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/auth/Register.tsx
+++ b/frontend/src/pages/auth/Register.tsx
@@ -84,12 +84,13 @@ const Register: React.FC = () => {
           </div>
           <p className="text-zinc-500 text-xs mb-8">
             Zapisz ten numer — będzie potrzebny przy każdym logowaniu.
+            Teraz ustawimy 4-cyfrowy kod PIN do potwierdzania transakcji.
           </p>
           <button
-            onClick={() => navigate('/login')}
+            onClick={() => navigate('/setup-pin')}
             className="w-full bg-blue-600 hover:bg-blue-500 text-white font-medium py-2.5 rounded-lg text-sm transition-colors"
           >
-            Przejdź do logowania
+            Ustaw kod PIN
           </button>
         </div>
       </div>

--- a/frontend/src/pages/auth/SetupPin.tsx
+++ b/frontend/src/pages/auth/SetupPin.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AlertCircle, ShieldCheck } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+
+const SetupPin: React.FC = () => {
+  const navigate = useNavigate();
+  const { setPin, user } = useAuth();
+  const [pin, setPinValue] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const isValid = /^\d{4}$/.test(pin) && pin === confirmPin;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (!/^\d{4}$/.test(pin)) {
+      setError('PIN musi składać się z dokładnie 4 cyfr.');
+      return;
+    }
+    if (pin !== confirmPin) {
+      setError('Kody PIN nie są identyczne.');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      await setPin(pin, confirmPin);
+      navigate('/dashboard');
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Nie udało się ustawić PIN-u. Spróbuj ponownie.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const onlyDigits = (value: string, setter: (v: string) => void) => {
+    const cleaned = value.replace(/\D/g, '').slice(0, 4);
+    setter(cleaned);
+    setError('');
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-950 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-8">
+          <div className="w-12 h-12 bg-blue-500/10 border border-blue-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
+            <ShieldCheck className="text-blue-400" size={22} />
+          </div>
+          <h1 className="text-xl font-semibold text-white text-center mb-2">Ustaw kod PIN</h1>
+          <p className="text-zinc-500 text-sm text-center mb-6">
+            {user?.customerNumber && (
+              <>Numer klienta: <span className="text-zinc-300 font-mono">{user.customerNumber}</span><br /></>
+            )}
+            Kod PIN będzie potrzebny do potwierdzania wszystkich operacji finansowych.
+          </p>
+
+          {error && (
+            <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/20 text-red-400 text-sm rounded-lg px-4 py-3 mb-5">
+              <AlertCircle size={16} className="shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-1.5">Nowy PIN (4 cyfry)</label>
+              <input
+                type="password"
+                inputMode="numeric"
+                autoComplete="new-password"
+                value={pin}
+                onChange={(e) => onlyDigits(e.target.value, setPinValue)}
+                placeholder="••••"
+                maxLength={4}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white text-center tracking-[0.6em] text-2xl rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-colors"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-1.5">Potwierdź PIN</label>
+              <input
+                type="password"
+                inputMode="numeric"
+                autoComplete="new-password"
+                value={confirmPin}
+                onChange={(e) => onlyDigits(e.target.value, setConfirmPin)}
+                placeholder="••••"
+                maxLength={4}
+                className={`w-full bg-zinc-800 border text-white text-center tracking-[0.6em] text-2xl rounded-lg px-4 py-3 focus:outline-none focus:ring-1 transition-colors ${
+                  confirmPin && confirmPin !== pin
+                    ? 'border-red-500/50 focus:border-red-500 focus:ring-red-500'
+                    : 'border-zinc-700 focus:border-blue-500 focus:ring-blue-500'
+                }`}
+              />
+              {confirmPin && confirmPin !== pin && (
+                <p className="text-xs text-red-400 mt-1">Kody PIN nie są identyczne</p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              disabled={!isValid || isLoading}
+              className="w-full bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 disabled:cursor-not-allowed text-white font-medium py-2.5 rounded-lg text-sm transition-colors flex items-center justify-center gap-2"
+            >
+              {isLoading ? (
+                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              ) : (
+                'Zapisz PIN'
+              )}
+            </button>
+          </form>
+        </div>
+
+        <p className="text-center text-xs text-zinc-600 mt-6">
+          Twojego PIN-u nikomu nie podawaj. Jest hashowany i przechowywany w bezpieczny sposób.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default SetupPin;

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -5,11 +5,13 @@ interface AuthResponse {
   email: string;
   role: string;
   customerNumber: string;
+  pinSet: boolean;
 }
 
 const login = async (customerNumber: string, password: string): Promise<AuthResponse> => {
   const { data } = await api.post<AuthResponse>('/api/auth/login', { customerNumber, password });
   localStorage.setItem('token', data.token);
+  localStorage.setItem('pinSet', String(data.pinSet));
   return data;
 };
 
@@ -23,10 +25,19 @@ const register = async (
     firstName, lastName, email, password,
   });
   localStorage.setItem('token', data.token);
+  localStorage.setItem('pinSet', String(data.pinSet));
   return data;
 };
 
-const logout = () => localStorage.removeItem('token');
+const setPin = async (pin: string, confirmPin: string): Promise<void> => {
+  await api.post('/api/auth/pin', { pin, confirmPin });
+  localStorage.setItem('pinSet', 'true');
+};
+
+const logout = () => {
+  localStorage.removeItem('token');
+  localStorage.removeItem('pinSet');
+};
 const getToken = () => localStorage.getItem('token');
 
-export const authService = { login, register, logout, getToken };
+export const authService = { login, register, setPin, logout, getToken };


### PR DESCRIPTION
## Co zostało zrobione

Implementacja 4-cyfrowego kodu PIN, którym klient potwierdza operacje finansowe — wzorowane na realnym flow bankowym.

### Flow użytkownika
- Po rejestracji klient zostaje przekierowany na ekran ustawiania PIN-u (zamiast od razu na login)
- PIN to dokładnie 4 cyfry, przechowywany w bazie tylko jako **BCrypt hash** (ten sam encoder co dla hasła)
- Każdy przelew wewnętrzny wymaga potwierdzenia PIN-em w modalu
- Po 3 nieudanych próbach PIN zostaje **zablokowany na 15 minut** — modal zmienia się w widok blokady z licznikiem MM:SS do odblokowania
- Po wygaśnięciu blokady countdown automatycznie znika i użytkownik znowu może wpisać PIN

### Bezpieczeństwo
- PIN nigdy nie leci w plaintext do bazy
- Licznik nieudanych prób zapisywany w osobnej transakcji (`REQUIRES_NEW`), żeby rollback przelewu nie cofał liczenia
- Backend zwraca strukturalne **HTTP 423 LOCKED** z polem `lockedUntil` (ISO timestamp ze strefą czasową) — frontend używa tego do countdownu, bez parsowania komunikatu
- Endpoint ustawiania PIN-u wymaga autoryzacji JWT (już zalogowany użytkownik, świeżo po rejestracji)

## Zmiany w schemacie
- V2: dodanie kolumn `users.pin_hash`, `users.pin_failed_attempts`, `users.pin_locked_until`
- Aktualizacja ERD w folderze docs i readme

## Plan testowy
- [x] Rejestracja → ekran z customer_number → przycisk "Ustaw PIN" → ekran ustawiania PIN-u → dashboard
- [x] Walidacja: PIN musi mieć dokładnie 4 cyfry
- [x] Walidacja: PIN i potwierdzenie PIN muszą być identyczne
- [x] Przelew wewnętrzny wymaga PIN-u — modal z 4 kropkami
- [x] Poprawny PIN → przelew się realizuje
- [x] Błędny PIN → komunikat "Pozostało prób: X"
- [x] Po 3 błędnych próbach → modal zmienia się w widok blokady z odliczaniem 15:00
- [x] Próba przelewu w trakcie blokady (np. po reloadzie) też trafia na 423 i pokazuje countdown
- [x] PIN w bazie jest BCrypt-hashowany (nigdy plaintext)