### PR TITLE
Bugfix

### DIFF
--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthService.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthService.java
@@ -6,6 +6,8 @@ import com.polishbank.bank_a.domain.auth.dto.RegisterRequest;
 import com.polishbank.bank_a.domain.user.User;
 import com.polishbank.bank_a.domain.user.UserRepository;
 import com.polishbank.bank_a.domain.user.UserRole;
+import com.polishbank.bank_a.entity.Account;
+import com.polishbank.bank_a.repository.AccountRepository;
 import com.polishbank.bank_a.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -13,13 +15,20 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
+    private static final String BANK_CODE = "88880000";
+    // "PL" zakodowane numerycznie wg ISO 13616: P=25, L=21
+    private static final String COUNTRY_CODE_NUMERIC = "2521";
+
     private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final AuthenticationManager authenticationManager;
@@ -37,6 +46,17 @@ public class AuthService {
                 .role(UserRole.CUSTOMER)
                 .build();
         userRepository.save(user);
+
+        Account account = Account.builder()
+                .user(user)
+                .accountNumber(generateAccountNumber())
+                .balance(BigDecimal.ZERO)
+                .blockedFunds(BigDecimal.ZERO)
+                .currency("PLN")
+                .type("STANDARD")
+                .build();
+        accountRepository.save(account);
+
         String token = jwtUtil.generateToken(user.getEmail(), user.getRole().name());
         return new AuthResponse(token, user.getEmail(), user.getRole().name(),
                 user.getCustomerNumber(), user.getPinHash() != null);
@@ -60,5 +80,28 @@ public class AuthService {
             number = String.format("%08d", random.nextInt(100_000_000));
         } while (userRepository.existsByCustomerNumber(number));
         return number;
+    }
+
+    private String generateAccountNumber() {
+        Random random = new Random();
+        String iban;
+        do {
+            StringBuilder bban = new StringBuilder(BANK_CODE); // 8 cyfr kodu banku
+            for (int i = 0; i < 16; i++) {                     // 16 cyfr numeru konta
+                bban.append(random.nextInt(10));
+            }
+            String checkDigits = computeIbanCheckDigits(bban.toString());
+            iban = "PL" + checkDigits + bban;
+        } while (accountRepository.findByAccountNumber(iban).isPresent());
+        return iban;
+    }
+
+    // Algorytm mod 97 (ISO 13616): BBAN + "PL" (jako 2521) + "00" -> mod 97
+    // cyfry kontrolne = 98 - mod
+    private String computeIbanCheckDigits(String bban) {
+        String rearranged = bban + COUNTRY_CODE_NUMERIC + "00";
+        int mod = new BigInteger(rearranged).mod(BigInteger.valueOf(97)).intValue();
+        int check = 98 - mod;
+        return String.format("%02d", check);
     }
 }

--- a/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthService.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/auth/AuthService.java
@@ -24,7 +24,6 @@ import java.util.Random;
 public class AuthService {
 
     private static final String BANK_CODE = "88880000";
-    // "PL" zakodowane numerycznie wg ISO 13616: P=25, L=21
     private static final String COUNTRY_CODE_NUMERIC = "2521";
 
     private final UserRepository userRepository;
@@ -57,7 +56,7 @@ public class AuthService {
                 .build();
         accountRepository.save(account);
 
-        String token = jwtUtil.generateToken(user.getEmail(), user.getRole().name());
+        String token = jwtUtil.generateToken(user.getEmail(), user.getRole().name(), user.getCustomerNumber());
         return new AuthResponse(token, user.getEmail(), user.getRole().name(),
                 user.getCustomerNumber(), user.getPinHash() != null);
     }
@@ -68,7 +67,7 @@ public class AuthService {
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(user.getEmail(), request.password())
         );
-        String token = jwtUtil.generateToken(user.getEmail(), user.getRole().name());
+        String token = jwtUtil.generateToken(user.getEmail(), user.getRole().name(), user.getCustomerNumber());
         return new AuthResponse(token, user.getEmail(), user.getRole().name(),
                 user.getCustomerNumber(), user.getPinHash() != null);
     }
@@ -96,8 +95,6 @@ public class AuthService {
         return iban;
     }
 
-    // Algorytm mod 97 (ISO 13616): BBAN + "PL" (jako 2521) + "00" -> mod 97
-    // cyfry kontrolne = 98 - mod
     private String computeIbanCheckDigits(String bban) {
         String rearranged = bban + COUNTRY_CODE_NUMERIC + "00";
         int mod = new BigInteger(rearranged).mod(BigInteger.valueOf(97)).intValue();

--- a/backend/src/main/java/com/polishbank/bank_a/domain/user/UserRepository.java
+++ b/backend/src/main/java/com/polishbank/bank_a/domain/user/UserRepository.java
@@ -1,13 +1,21 @@
 package com.polishbank.bank_a.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-    Optional<User> findByEmail(String email);
+
+    @Query("SELECT u FROM User u WHERE LOWER(u.email) = LOWER(:email)")
+    Optional<User> findByEmail(@Param("email") String email);
+
     Optional<User> findByCustomerNumber(String customerNumber);
-    boolean existsByEmail(String email);
+
+    @Query("SELECT COUNT(u) > 0 FROM User u WHERE LOWER(u.email) = LOWER(:email)")
+    boolean existsByEmail(@Param("email") String email);
+
     boolean existsByCustomerNumber(String customerNumber);
 }

--- a/backend/src/main/java/com/polishbank/bank_a/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/polishbank/bank_a/security/JwtAuthFilter.java
@@ -9,6 +9,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -40,11 +41,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String email = jwtUtil.extractEmail(token);
         if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-            UsernamePasswordAuthenticationToken auth =
-                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-            auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-            SecurityContextHolder.getContext().setAuthentication(auth);
+            try {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (UsernameNotFoundException ex) {
+            }
         }
         chain.doFilter(request, response);
     }

--- a/backend/src/main/java/com/polishbank/bank_a/security/JwtUtil.java
+++ b/backend/src/main/java/com/polishbank/bank_a/security/JwtUtil.java
@@ -21,10 +21,11 @@ public class JwtUtil {
         return Keys.hmacShaKeyFor(jwtconfig.getSecret().getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateToken(String email, String role) {
+    public String generateToken(String email, String role, String customerNumber) {
         return Jwts.builder()
                 .subject(email)
                 .claim("role", role)
+                .claim("customerNumber", customerNumber)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + jwtconfig.getExpirationsMs()))
                 .signWith(signingKey())

--- a/backend/src/main/java/com/polishbank/bank_a/security/UserDetailServiceImpl.java
+++ b/backend/src/main/java/com/polishbank/bank_a/security/UserDetailServiceImpl.java
@@ -24,7 +24,7 @@ public class UserDetailServiceImpl implements UserDetailsService {
         return new User (
             user.getEmail(),
             user.getPasswordHash(),
-            List.of(new SimpleGrantedAuthority("Role_" + user.getRole().name()))
+            List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
         );
     }
 }

--- a/backend/src/test/java/com/polishbank/bank_a/domain/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/polishbank/bank_a/domain/auth/AuthServiceTest.java
@@ -6,7 +6,6 @@ import com.polishbank.bank_a.domain.auth.dto.RegisterRequest;
 import com.polishbank.bank_a.domain.user.User;
 import com.polishbank.bank_a.domain.user.UserRepository;
 import com.polishbank.bank_a.domain.user.UserRole;
-import com.polishbank.bank_a.repository.AccountRepository;
 import com.polishbank.bank_a.security.JwtUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +28,6 @@ class AuthServiceTest {
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtUtil jwtUtil;
     @Mock private AuthenticationManager authenticationManager;
-    @Mock private AccountRepository accountRepository;
 
     @InjectMocks private AuthService authService;
 
@@ -41,7 +39,7 @@ class AuthServiceTest {
         when(userRepository.existsByCustomerNumber(anyString())).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("$2a$hashed");
         when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        when(jwtUtil.generateToken("jan@test.pl", "CUSTOMER")).thenReturn("jwt-token");
+        when(jwtUtil.generateToken(eq("jan@test.pl"), eq("CUSTOMER"), anyString())).thenReturn("jwt-token");
 
         AuthResponse response = authService.register(request);
 
@@ -65,15 +63,16 @@ class AuthServiceTest {
 
     @Test
     void login_success_returnsToken() {
-        LoginRequest request = new LoginRequest("jan@test.pl", "password123");
+        LoginRequest request = new LoginRequest("12345678", "password123");
         User user = User.builder()
+                .customerNumber("12345678")
                 .email("jan@test.pl")
                 .passwordHash("$2a$hashed")
                 .role(UserRole.CUSTOMER)
                 .build();
 
-        when(userRepository.findByEmail("jan@test.pl")).thenReturn(Optional.of(user));
-        when(jwtUtil.generateToken("jan@test.pl", "CUSTOMER")).thenReturn("jwt-token");
+        when(userRepository.findByCustomerNumber("12345678")).thenReturn(Optional.of(user));
+        when(jwtUtil.generateToken(eq("jan@test.pl"), eq("CUSTOMER"), eq("12345678"))).thenReturn("jwt-token");
 
         AuthResponse response = authService.login(request);
 

--- a/backend/src/test/java/com/polishbank/bank_a/domain/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/polishbank/bank_a/domain/auth/AuthServiceTest.java
@@ -6,6 +6,7 @@ import com.polishbank.bank_a.domain.auth.dto.RegisterRequest;
 import com.polishbank.bank_a.domain.user.User;
 import com.polishbank.bank_a.domain.user.UserRepository;
 import com.polishbank.bank_a.domain.user.UserRole;
+import com.polishbank.bank_a.repository.AccountRepository;
 import com.polishbank.bank_a.security.JwtUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,7 @@ class AuthServiceTest {
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtUtil jwtUtil;
     @Mock private AuthenticationManager authenticationManager;
+    @Mock private AccountRepository accountRepository;
 
     @InjectMocks private AuthService authService;
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import AddJunior from './pages/junior/AddJunior.tsx'
 import CardsPage from './pages/cards/CardsPage.tsx'
 import PendingApprovals from './pages/junior/PendingApprovals.tsx'
 import ManageJunior from './pages/junior/ManageJunior.tsx'
+import SetupPin from './pages/auth/SetupPin.tsx'
 
 
 function App() {
@@ -68,6 +69,12 @@ function App() {
             <ManageJunior />
           </ProtectedRoute>
         } />
+
+        <Route path={ROUTES.SETUP_PIN} element={
+          <ProtectedRoute>
+            <SetupPin />
+          </ProtectedRoute>
+        }/>
       </Routes>
     </AuthProvider>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import KlikAuthorizationWatcher from './components/KlikAuthorizationWatcher'
 import Home from './pages/Home.tsx'
 import Login from './pages/auth/Login.tsx'
 import Register from './pages/auth/Register.tsx'
+import SetupPin from './pages/auth/SetupPin.tsx'
 import Dashboard from './pages/Dashboard.tsx'
 import TransactionHistory from './pages/TransactionHistory';
 import InternalTransfer from './pages/auth/InternalTransfer';
@@ -14,7 +15,6 @@ import AddJunior from './pages/junior/AddJunior.tsx'
 import CardsPage from './pages/cards/CardsPage.tsx'
 import PendingApprovals from './pages/junior/PendingApprovals.tsx'
 import ManageJunior from './pages/junior/ManageJunior.tsx'
-import SetupPin from './pages/auth/SetupPin.tsx'
 
 
 function App() {
@@ -25,6 +25,11 @@ function App() {
         <Route path={ROUTES.HOME} element={<Home/>}/>
         <Route path={ROUTES.LOGIN} element={<Login/>}/>
         <Route path={ROUTES.REGISTER} element={<Register/>}/>
+        <Route path={ROUTES.SETUP_PIN} element={
+          <ProtectedRoute>
+            <SetupPin />
+          </ProtectedRoute>
+        }/>
         <Route path={ROUTES.DASHBOARD} element={
           <ProtectedRoute>
             <Dashboard/>
@@ -69,12 +74,6 @@ function App() {
             <ManageJunior />
           </ProtectedRoute>
         } />
-
-        <Route path={ROUTES.SETUP_PIN} element={
-          <ProtectedRoute>
-            <SetupPin />
-          </ProtectedRoute>
-        }/>
       </Routes>
     </AuthProvider>
   )

--- a/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/frontend/src/components/layout/ProtectedRoute.tsx
@@ -3,6 +3,15 @@ import { useAuth } from '../../contexts/AuthContext';
 import type { ReactNode } from 'react';
 
 export function ProtectedRoute({ children }: { children: ReactNode }) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-zinc-950 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" replace />;
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ interface AuthUser { email: string; role: string; customerNumber: string; pinSet
 
 interface AuthContextType {
   user: AuthUser | null;
+  loading: boolean;
   login: (customerNumber: string, password: string) => Promise<void>;
   register: (firstName: string, lastName: string, email: string, password: string) => Promise<string>;
   setPin: (pin: string, confirmPin: string) => Promise<void>;
@@ -17,6 +18,7 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -35,6 +37,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         localStorage.removeItem('pinSet');
       }
     }
+    setLoading(false);
   }, []);
 
   const login = async (customerNumber: string, password: string) => {
@@ -60,7 +63,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, setPin, logout, isAuthenticated: !!user }}>
+    <AuthContext.Provider value={{ user, loading, login, register, setPin, logout, isAuthenticated: !!user }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -239,7 +239,7 @@ export default function Dashboard() {
                     )}
                   </div>
 
-                  <section className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
+                  <section className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-6">
                     <button
                       onClick={() => navigate('/cards')}
                       className="bg-zinc-900 border border-zinc-800 p-4 rounded-xl flex flex-col items-center justify-center gap-3 hover:bg-zinc-800/80 hover:border-zinc-700 transition-all group">
@@ -251,25 +251,17 @@ export default function Dashboard() {
                     <button
                       onClick={() => navigate('/klik/code')}
                       className="bg-zinc-900 border border-zinc-800 p-4 rounded-xl flex flex-col items-center justify-center gap-3 hover:bg-zinc-800/80 hover:border-zinc-700 transition-all group">
-                      <div className="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center text-zinc-400 group-hover:text-blue-400 group-hover:bg-blue-500/10 transition-colors font-bold text-sm">BLIK</div>
-                      <span className="text-sm font-medium text-zinc-300">Kod BLIK</span>
+                      <div className="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center text-zinc-400 group-hover:text-blue-400 group-hover:bg-blue-500/10 transition-colors font-bold text-sm">KLIK</div>
+                      <span className="text-sm font-medium text-zinc-300">Kod KLIK</span>
                     </button>
 
                     {!isJunior && (
-                      <>
-                        <button className="bg-zinc-900 border border-zinc-800 p-4 rounded-xl flex flex-col items-center justify-center gap-3 hover:bg-zinc-800/80 hover:border-zinc-700 transition-all group">
-                          <div className="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center text-zinc-400 group-hover:text-blue-400 group-hover:bg-blue-500/10 transition-colors">
-                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z" /></svg>
-                          </div>
-                          <span className="text-sm font-medium text-zinc-300">Inne banki</span>
-                        </button>
-                        <button className="bg-zinc-900 border border-zinc-800 p-4 rounded-xl flex flex-col items-center justify-center gap-3 hover:bg-zinc-800/80 hover:border-zinc-700 transition-all group">
-                          <div className="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center text-zinc-400 group-hover:text-blue-400 group-hover:bg-blue-500/10 transition-colors">
-                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" /></svg>
-                          </div>
-                          <span className="text-sm font-medium text-zinc-300">Wiadomości</span>
-                        </button>
-                      </>
+                      <button className="bg-zinc-900 border border-zinc-800 p-4 rounded-xl flex flex-col items-center justify-center gap-3 hover:bg-zinc-800/80 hover:border-zinc-700 transition-all group">
+                        <div className="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center text-zinc-400 group-hover:text-blue-400 group-hover:bg-blue-500/10 transition-colors">
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z" /></svg>
+                        </div>
+                        <span className="text-sm font-medium text-zinc-300">Inne banki</span>
+                      </button>
                     )}
                   </section>
                 </div>
@@ -378,7 +370,7 @@ export default function Dashboard() {
                       </div>
                       <div className="text-left">
                         <p className="text-sm font-medium text-zinc-200">Przelew na telefon</p>
-                        <p className="text-xs text-zinc-500">Natychmiastowy BLIK</p>
+                        <p className="text-xs text-zinc-500">Natychmiastowy KLIK</p>
                       </div>
                     </div>
                   </button>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,13 +1,20 @@
 import axios from 'axios';
 
+const AUTH_ENDPOINTS = ['/api/auth/login', '/api/auth/register'];
+
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8080', 
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8080',
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
 api.interceptors.request.use((config) => {
+  const url = config.url || '';
+  const isAuthEndpoint = AUTH_ENDPOINTS.some((path) => url.endsWith(path));
+  if (isAuthEndpoint) {
+    return config;
+  }
   const token = localStorage.getItem('token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
## Cel

Naprawa głównego buga: przy rejestracji nowego użytkownika nie tworzyło się dla niego konto w banku. Przy okazji uporządkowane kilka zaległych problemów w autoryzacji i frontendzie, które dawały o sobie znać przy testowaniu rejestracji/logowania.

## Zmiany

### Backend

- **Tworzenie konta bankowego przy rejestracji** (`AuthService`) — nowy klient od razu dostaje konto typu `STANDARD` w PLN z saldem 0 zł i prawidłowym numerem IBAN (algorytm mod 97 wg ISO 13616, z kodem banku `88880000`).
- **`customerNumber` w JWT** (`JwtUtil`, `AuthService`) — token zawiera teraz claim `customerNumber`, dzięki czemu frontend po F5 / odświeżeniu strony nadal zna numer klienta zalogowanego usera.
- **Poprawiony prefiks autorytetów** (`UserDetailServiceImpl`) — `Role_` → `ROLE_`, dzięki czemu Spring Security `hasRole(...)` / `@PreAuthorize` faktycznie działa.
- **Odporność `JwtAuthFilter` na stare tokeny** — łapanie `UsernameNotFoundException`, gdy token wskazuje na nieistniejącego usera (np. po resecie bazy). Wcześniej każde takie żądanie kończyło się 500 i blokowało nawet logowanie.
- **Case-insensitive email** (`UserRepository`) — `findByEmail` / `existsByEmail` używają `LOWER(...)`, więc rejestracja jako `Anna@x.pl` i logowanie jako `anna@x.pl` traktowane są spójnie.

### Frontend

- **Route `/setup-pin`** (`App.tsx`) — ekran ustawiania PIN-u po rejestracji miał już komponent i stałą w `routes.tsx`, ale brakowało wpisu w `Routes`. Skutek: po rejestracji biała strona. Dodany jako chroniony route.
- **Sesja po F5** (`AuthContext`, `ProtectedRoute`) — dodany stan `loading` w `AuthContext`. `ProtectedRoute` czeka aż odczytany zostanie token z `localStorage`, zanim ewentualnie zrobi redirect na `/login`. Wcześniej każde odświeżenie wyrzucało zalogowanego użytkownika.
- **Czysty interceptor axios** (`api.ts`) — `Authorization: Bearer ...` nie jest już doklejany do `/api/auth/login` i `/api/auth/register`. Stary token nie blokuje już nowych logowań.
- **Porządki w dashboardzie** — usunięty martwy przycisk „Wiadomości" (nigdy nie miał `onClick`), siatka przycisków zmieniona z 4 na 3 kolumny, podpisy `BLIK` → `KLIK` żeby były spójne z nazwą integrowanego systemu.

### Testy

- `AuthServiceTest` zaktualizowany pod nową sygnaturę `JwtUtil.generateToken(email, role, customerNumber)` i nowy mock `AccountRepository`. Test `login_success_returnsToken` doprowadzony do zgodności z aktualnym `LoginRequest` (numer klienta zamiast emaila).

## Jak przetestować

1. `docker compose down -v && docker compose up --build` — czysta baza, seeder zasieje testowych userów.
2. **Rejestracja:** zarejestruj nowego usera → powinieneś wylądować na ekranie ustawiania PIN-u, a po nim na dashboardzie z kontem osobistym (saldo 0 zł, numer IBAN zaczynający się od `PL` + 8 cyfr `88880000`).
3. **Logowanie:** zaloguj się jako `84920183` / `password` (Ewa Majewska z seedera) — wszystko działa.
4. **F5 na dashboardzie** — nie wyrzuca już na login.
5. **Stary token + reset bazy:** zaloguj się, zrób `docker compose down -v && up`, spróbuj się ponownie zalogować w tej samej zakładce — działa (wcześniej każde żądanie wywalało 500).
6. **Wielkość liter w emailu:** zarejestruj `Test@Example.pl`, potem spróbuj zarejestrować `test@example.pl` — backend odrzuca jako duplikat.